### PR TITLE
Use props instead of refs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,9 @@ import React, { Component } from 'react'
 export default class ResizeAware extends Component {
   constructor() {
     super()
-    this.state = {}
+    this.state = { resizeTarget: undefined }
   }
+  
   render() {
     let rootStyle = this.props.style || {}
     if (rootStyle.position === 'initial') {
@@ -48,25 +49,21 @@ export default class ResizeAware extends Component {
   }
 
   componentWillUnmount() {
-    this.state.resizeTarget && this.state.resizeTarget.removeEventListener('resize', this.state.resizeFn)
-  }
-
-  // function called on component resize
-  // a `resize` event will be triggered on the component
-  onResize(evt) {
-    var event = document.createEvent('Event');
-    event.initEvent('resize', true, true);
-    this.refs.container.dispatchEvent(event)
+    this.state.resizeTarget && this.state.resizeTarget.removeEventListener('resize', this.props.onResize)
   }
 
   // called when the object is loaded
   objectLoad(evt) {
     this.setState({
-      resizeTarget: evt.target.contentDocument.defaultView,
-      resizeFn: this.onResize.bind(this)
-    }, function() {
-      this.state.resizeTarget.addEventListener('resize', this.state.resizeFn)
+      resizeTarget: evt.target.contentDocument.defaultView
+    }, () => {
+      // the onResize prop is triggered on every 'resize' event
+      this.state.resizeTarget && this.state.resizeTarget.addEventListener('resize', this.props.onResize)
     })
   }
 
+}
+
+ResizeAware.propTypes = {
+  onResize: React.PropTypes.func.isRequired
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default class ResizeAware extends Component {
     }
 
     return (
-      <div ref='container' {...this.props} style={rootStyle}>
+      <div style={rootStyle}>
         {this.props.children}
         <object
           type='text/html'


### PR DESCRIPTION
I like what you've done with the component and thought it would be more natural to use in React if instead of having a ref to the actual DOM element, we would use a prop. Any thoughts or pitfalls you'd see with this approach?

Example:
```js
import React, { Component } from 'react'
import ResizeAware from 'react-resize-aware'

export default class FooBar extends Component {
  render() {
    return (
      <ResizeAware onResize={this.onResize} style={{position: 'relative'}}>
        Hello, World!
      </ResizeAware>
    )
  }

  onResize() {
    console.log('Component has been resized!')
  }
}
```

Please test and let me know what you think!