### PR TITLE
Add visibility hidden to style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import {
 
 const style = {
   display: 'block',
+  visibility: 'hidden',
   position: 'absolute',
   top: 0,
   left: 0,


### PR DESCRIPTION
This PR adds `  visibility: 'hidden'` to the `style` object, which is necessary in IE11. Without it, the object is visible. See screenshot below.

![image](https://user-images.githubusercontent.com/8732191/38218202-97f3b562-3696-11e8-83d4-f15d71740deb.png)