### PR TITLE
Handle case where resizeTarget is not an event listener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,8 +57,15 @@ export default class ResizeAware extends Component {
   };
 
   componentWillUnmount() {
-    this.state.resizeTarget &&
-      this.state.resizeTarget.removeEventListener('resize', this.handleResize);
+    const { resizeTarget } = this.state;
+
+    // ensure the resizeTarget exists and is in fact an event listener
+    // this fixes an issue where contentDocument.defaultView is not a real window object
+    // as can be the case when used with react portals
+    const isListener = resizeTarget && typeof(resizeTarget.removeEventListener) === 'function';
+
+    isListener &&
+      resizeTarget.removeEventListener('resize', this.handleResize);
   }
 
   // Function called on component resize


### PR DESCRIPTION
@FezVrasta many thanks for this library. I've been using it with popper.js and it is 💯 

I ran into an issue recently with Safari throwing errors when using this component inside of a react portal.

It seems that in this browser React stubs in a window for `contentDocument.defaultView` that is not actually an event listener. So when `ResizeAware`  unmounts in Safari - it throws an error complaining that `removeEventListener` is not a function.

I included a simple fix that solves my issues, and might just make things more robust in general?

Let me know if I can do anything to help get this merged 😄 

Many thanks again for the work you do on these libs!