### PR TITLE
Remove unnecessary dependency from useMemo hook

### DIFF
--- a/src/useResizeAware.js
+++ b/src/useResizeAware.js
@@ -15,7 +15,7 @@ export default function useResizeAware(
 
   const MemoResizeListener = React.useMemo(
     () => () => <ResizeListener onResize={onResize} />,
-    [setSizes, reporter]
+    [reporter]
   );
 
   return [MemoResizeListener, sizes];


### PR DESCRIPTION
setState received from useState has a constant reference