### PR TITLE
fix wrong first-time value with custom reporter

### DIFF
--- a/src/useResizeAware.js
+++ b/src/useResizeAware.js
@@ -10,7 +10,7 @@ const defaultReporter = (target: ?HTMLElement) => ({
 export default function useResizeAware(
   reporter: typeof defaultReporter = defaultReporter
 ) {
-  const [sizes, setSizes] = React.useState({ width: null, height: null });
+  const [sizes, setSizes] = React.useState(reporter(null));
   const onResize = React.useCallback(ref => setSizes(reporter(ref.current)), [
     reporter,
   ]);


### PR DESCRIPTION
If custom reporter is used, first-time hook value is still coming from default reporter, always `{width: null, height: null}`. This fix calls the custom reporter with `null` to get first-time value.