### PR TITLE
Fix Can't import the named export 'createElement'

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "main": "dist/index.js",
   "umd:main": "dist/index.umd.js",
-  "module": "dist/index.mjs",
   "source": "src/index.js",
   "scripts": {
     "start": "microbundle watch",


### PR DESCRIPTION
I tried to switch to beta 6 and got the following webpack error (and same ones for some other exports):

> Can't import the named export 'createElement' from non EcmaScript module (only default export is available)

A bit of searching showed that there's a problem with default webpack config and packages that export .mjs files. More details here: https://github.com/apollographql/react-apollo/issues/1737
This PR removes the mjs entry from package.json.